### PR TITLE
DOCS: Fix the example instantiation of unexpected-webdriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,8 @@ Selene does not come with its own test runner nor is it bound to a specific asse
 ```js
 var selene = require('selene');
 var expect = require('unexpected');
- expect.use(require('unexpected-webdriver'));
+
+expect.use(require('unexpected-webdriver')());
 
 describe('Google', function () {
 


### PR DESCRIPTION
Running the example without the instantiation of the `unexpected-webdriver` package results in unexpected to exit with code 1 since the `contain text` assertion is still unknown.